### PR TITLE
Adjust imputation conditional statement

### DIFF
--- a/R/est.gformula.R
+++ b/R/est.gformula.R
@@ -392,7 +392,7 @@ est.gformula <- function(data = NULL, indices = NULL, outReg = FALSE, full = TRU
     
     ## output effects on the odds ratio scale for logistic regressions
     if (is_glm_yreg && family_yreg$family %in% c("binomial", "quasibinomial") &&
-        yreg$family$link == "logit") {
+        family_yreg$link == "logit") {
       logRRcde <- log(EY1m/(1-EY1m)) - log(EY0m/(1-EY0m))
       logRRpnde <- log(EY10/(1-EY10)) - log(EY00/(1-EY00))
       logRRtnde <- log(EY11/(1-EY11)) - log(EY01/(1-EY01))

--- a/R/est.rb.R
+++ b/R/est.rb.R
@@ -462,7 +462,7 @@ est.rb <- function(data = NULL, indices = NULL, outReg = FALSE, full = TRUE) {
       
       ## output effects on the odds ratio scale for logistic regressions
       if (is_glm_yreg && family_yreg$family %in% c("binomial", "quasibinomial") &&
-          yreg$family$link == "logit") {
+          family_yreg$link == "logit") {
         logRRcde <- log(EY1m/(1-EY1m)) - log(EY0m/(1-EY0m))
         logRRpnde <- log(EY10/(1-EY10)) - log(EY00/(1-EY00))
         logRRtnde <- log(EY11/(1-EY11)) - log(EY01/(1-EY01))


### PR DESCRIPTION
# Description

Addresses bug noted in #35 , which allows estimation of causal effects from both rb, and gformula models using `estimation = "imputation"` from `cmest()` and `cmsens()`.

# Changes

The following minor fix has been added to `est.rb()` and `est.gformula()`
```
if (is_glm_yreg && family_yreg$family %in% c("binomial", "quasibinomial") &&
          family_yreg$link == "logit")
```

